### PR TITLE
Rework mirroring multiple template instances to multiple independent template instances

### DIFF
--- a/InputfieldSplashAndGrab.js
+++ b/InputfieldSplashAndGrab.js
@@ -1,47 +1,56 @@
 $(document).ready(function () {
 
-    let apiKey = "TXtTckxpjGAtu33DZ712disnUcTMpMqR-AdPepgS0pU",
-        startPage = 1,
+     let apiKey = "TXtTckxpjGAtu33DZ712disnUcTMpMqR-AdPepgS0pU",
         totalHits,
         totalPages,
         perPage,
-        chosenOrientation,
-        chosenColor,
-        chosenOrder,
         moduleConfig = config.InputfieldSplashAndGrab; // Config settings as defined by PageListPermissions.module
+
+    const $maxFiles = [],
+          $uploadedFiles = [],
+          $results = [],
+          $chosen = [],
+          chosenColor = [],
+          chosenOrientation = [],
+          chosenOrder = [],
+          startPage = [];
+
 
     $('.unsplashSearch').val($("#Inputfield_title").val());
     $numGridImg = $(".gridImages .gridImage:not('.gridImage--delete')").length;
     $('.unsplashButton').on('click', function (e) {
 
-        //reset pager to defautl values
-        chosenOrientation = undefined;
-        chosenColor = undefined;
-        chosenOrder = undefined;
 
         e.preventDefault()
-        $maxFiles = $("#splashAndGrab").data('maxfiles');
-        $uploadedFiles = $("#splashAndGrab").data('uploadedfiles');
+        parent_sag = $(this).closest('.unsplash');
+        field_name = parent_sag.data('name');
+        field_id = parent_sag.data('fieldid');
+
+        //reset pager to defautl values
+        chosenOrientation[field_id] = undefined;
+        chosenColor[field_id] = undefined;
+        chosenOrder[field_id] = undefined;
+
+        page_id = parent_sag.data('id');
+        $maxFiles[field_id] = $("#splashAndGrab_" + field_id).data('maxfiles');
+        $uploadedFiles[field_id] = $("#splashAndGrab_" + field_id).data('uploadedfiles');
         sizesFound = 0;
         descsFound = 0;
-        $results = $('.unsplashResults');
+        $results[field_id] = $('#unsplashResults_'+field_id);
         $resultItems = $('.resultsItems');
-        $chosen = $('.unsplashChosen');
-        $results.html('');
-        field_name = $("#splashAndGrab").data('name');
-        page_id = $("#splashAndGrab").data('id');
-        $results.addClass('unsplashLoading');
-        
+        $chosen[field_id] = $('#unsplashChosen_'+field_id);
+        $results[field_id].html('');
+        $results[field_id].addClass('unsplashLoading');
 
-        let query = $('#unsplashMagic').val();
+        let query = $('#unsplashMagic_'+field_id).val();
         $button = $(this);
-        getImages(query);
+        getImages(query, undefined, undefined, undefined, undefined, undefined, field_id);
         return false;
     });
     var sortValues = ['relevant', 'latest'];
     var orientation = ['landscape', 'portrait', 'squarish'];
     var colors = ['black_and_white', 'black', 'white', 'yellow', 'orange', 'red', 'purple', 'magenta', 'green', 'teal', 'blue'];
-    function getImages(searchterm, page = 1, per_page = 15, order, color, orientation) {
+    function getImages(searchterm, page = 1, per_page = 15, order, color, orientation, fid) {
         
         $.getJSON("https://api.unsplash.com/search/photos",
             {
@@ -59,69 +68,87 @@ $(document).ready(function () {
                 totalPages = data.total_pages;
                 perPage = per_page;
 
-                $results.children().remove();
+                $results[fid].children().remove();
 
                 if (data.results.length == 0) {
-                   noHits();
+                   noHits(fid);
                 } 
                 
-                renderPager();
+                renderPager(fid);
                
                 $.each(data.results, function (item) {
                     let itemNo = data.results[item];
-                    renderImage(itemNo);
+                    renderImage(itemNo,fid);
                 });
 
-                $("#numSelected").html($(".unsplashChosen .selected").length);
+                $("#numSelected_"+fid).html($("#unsplashChosen_"+fid+" .selected").length);
             });
     }
 
-    function noHits(){
+    function noHits(fid){
         $sorryString = moduleConfig.i18n.noHits;
-        $results.html($sorryString);
+        $results[fid].html($sorryString);
     }
 
-    $("body").on("change", "#unsplashOriantation",function(){
-        let query = $("#unsplashMagic").val();
-        chosenOrientation = this.value;
-        if (!chosenOrientation) chosenOrientation = undefined; 
-        startPage = 1;
-        getImages(query, startPage, perPage, chosenOrder, chosenColor, chosenOrientation);
+
+    $("fieldset.unsplash").each(function(key, val) {
+        let refid = $(val).attr("data-fieldid");
+
+        $("body").on("change", "#unsplashOriantation_"+refid,function(){
+            let query = $("#unsplashMagic_"+refid).val();
+            chosenOrientation[refid] = this.value;
+            if (!chosenOrientation[refid]) chosenOrientation[refid] = undefined; 
+            startPage[refid] = 1;
+            getImages(query, startPage[refid], perPage, chosenOrder[refid], chosenColor[refid], chosenOrientation[refid], refid);
+        });
+
+        $("body").on("change", "#unsplashColor_"+refid, function () {
+            let query = $("#unsplashMagic_"+refid).val();
+            chosenColor[refid] = this.value;
+            if (!chosenColor[refid]) chosenColor[refid] = undefined; 
+            startPage[refid] = 1;
+            getImages(query, startPage[refid], perPage, chosenOrder[refid], chosenColor[refid], chosenOrientation[refid], refid);
+        });
+
+        $("body").on("change", "#unsplashOrder_"+refid, function () {
+            let query = $("#unsplashMagic_"+refid).val();
+            chosenOrder[refid] = this.value;
+            if (!chosenOrder[refid]) chosenOrder[refid] = undefined;
+            startPage[refid] = 1;
+            getImages(query, startPage[refid], perPage, chosenOrder[refid], chosenColor[refid], chosenOrientation[refid], refid);
+        });
+
+        $("body").on("click", "#nextPager_"+refid, function(event){
+            event.preventDefault();
+            let query = $("#unsplashMagic_"+refid).val();
+            startPage[refid]++;
+            getImages(query, startPage[refid], perPage, chosenOrder[refid], chosenColor[refid], chosenOrientation[refid], refid);
+        });
+
+        $("body").on("click", "#prevPager_"+refid, function (event) {
+            event.preventDefault();
+            let query = $("#unsplashMagic_"+refid).val();
+            startPage[refid]--;
+            getImages(query, startPage[refid], perPage, chosenOrder[refid], chosenColor[refid], chosenOrientation[refid], refid);
+        });
+
+        $(document).on("click", "#numSelected_"+refid, function(){
+            $("#unsplashChosen_"+refid).toggle();
+        })
+
+        window.addEventListener("beforeunload", function () {
+            $("#unsplashChosen_"+refid).children().each(function(){
+                $.ajax({
+                    type: 'GET',
+                    async: true,
+                    url: $(this).data("download") + '?client_id=' + apiKey,
+                });
+                
+            })
+            sessionStorage.clear();
+        });        
     });
 
-    $("body").on("change", "#unsplashColor", function () {
-        let query = $("#unsplashMagic").val();
-        chosenColor = this.value;
-        if (!chosenColor) chosenColor = undefined; 
-        startPage = 1;
-        getImages(query, startPage, perPage, chosenOrder, chosenColor, chosenOrientation);
-    });
-
-    $("body").on("change", "#unsplashOrder", function () {
-        let query = $("#unsplashMagic").val();
-        chosenOrder = this.value;
-        if (!chosenOrder) chosenOrder = undefined;
-        startPage = 1;
-        getImages(query, startPage, perPage, chosenOrder, chosenColor, chosenOrientation);
-    });
-
-    $("body").on("click", "#nextPager", function(event){
-        event.preventDefault();
-        let query = $("#unsplashMagic").val();
-        startPage++;
-        getImages(query, startPage, perPage, chosenOrder, chosenColor, chosenOrientation);
-    });
-
-    $("body").on("click", "#prevPager", function (event) {
-        event.preventDefault();
-        let query = $("#unsplashMagic").val();
-        startPage--;
-        getImages(query, startPage, perPage, chosenOrder, chosenColor, chosenOrientation);
-    });
-
-    $(document).on("click", "#numSelected", function(){
-        $(".unsplashChosen").toggle();
-    })
 
     function addToLocalstorage(img) {
         sessionStorage.setItem(img, img);
@@ -131,16 +158,16 @@ $(document).ready(function () {
         sessionStorage.removeItem(img)
     }
 
-    function renderColorSelect(){
+    function renderColorSelect(fid){
         let options;
         for (let index = 0; index < colors.length; index++) {
 
             let configIndex = colors[index];
-            let selected = chosenColor == configIndex ? "selected" : "";
+            let selected = chosenColor[fid] == configIndex ? "selected" : "";
             options += "<option " + selected + " value='" + configIndex + "'>" + moduleConfig.i18n[configIndex] + "</option>";
         }
         $colorsOut = `
-        <select class="uk-select" id="unsplashColor">
+        <select class="uk-select" id="unsplashColor_${fid}">
         <option value="">${moduleConfig.i18n.colors}</option>
         ${ options }
          </select >
@@ -149,16 +176,16 @@ $(document).ready(function () {
         return $colorsOut;
     }
 
-    function renderOrientationSelect(){
+    function renderOrientationSelect(fid){
         let options = "";
         for (let index = 0; index < orientation.length; index++) {
 
             let configIndex = orientation[index];
-            let selected = chosenOrientation == configIndex ? "selected" : "";
+            let selected = chosenOrientation[fid] == configIndex ? "selected" : "";
             options += "<option " + selected + " value='" + configIndex + "'>" + moduleConfig.i18n[configIndex] + "</option>";
         }
         let optionsOut = `
-        <select id="unsplashOriantation" class="uk-select">
+        <select id="unsplashOriantation_${fid}" class="uk-select">
             <option value="">${moduleConfig.i18n.orientaions}</option>
             ${options}
         </select>`;
@@ -166,41 +193,41 @@ $(document).ready(function () {
         return optionsOut;
     }
 
-    function renderOrderSelect(){
+    function renderOrderSelect(fid){
         let options = "";
         for (let index = 0; index < sortValues.length; index++) {
 
             let configIndex = sortValues[index];
-            let selected = chosenOrder == configIndex ? "selected" : "";
+            let selected = chosenOrder[fid] == configIndex ? "selected" : "";
             options += "<option " + selected + " value='" + configIndex + "'>" + moduleConfig.i18n[configIndex] + "</option>";
         }
         let orderOut = `
-        <select id="unsplashOrder" class="uk-select">
+        <select id="unsplashOrder_${fid}" class="uk-select">
             ${options}
         </select>`;
 
         return orderOut;
     }
 
-    function renderPager(){
-        let disablePrev = startPage < 2 ? "disabled" : "" ;
-        let disableNext = totalPages == startPage ? "disabled" : "";
+    function renderPager(fid){
+        let disablePrev = startPage[fid] < 2 ? "disabled" : "" ;
+        let disableNext = totalPages == startPage[fid] ? "disabled" : "";
         
         $("#numSelected").html();
         let pager = `
         <div class="uk-margin">
-            <button ${disablePrev} id="prevPager" class="uk-button uk-button-primary uk-button-small">
+            <button ${disablePrev} id="prevPager_${fid}" class="uk-button uk-button-primary uk-button-small">
             <span uk-icon='icon: chevron-left'></span></button>
-            <button ${disableNext} id="nextPager" class="uk-button uk-button-primary uk-button-small">
+            <button ${disableNext} id="nextPager_${fid}" class="uk-button uk-button-primary uk-button-small">
                 <span uk-icon='icon: chevron-right'></span>
             </button>
-            <span class="uk-margin-left uk-text-small">${moduleConfig.i18n.numberOfSelects}: </span><span id="numSelected" class="uk-button uk-button-primary uk-button-small"></span><span class="uk-margin-small-left" title="${moduleConfig.i18n.title_numoffiles}">${moduleConfig.i18n.of} ${$maxFiles}</span>
-            ${renderOrientationSelect()}
-            ${renderColorSelect()}
-            ${renderOrderSelect()}
+            <span class="uk-margin-left uk-text-small">${moduleConfig.i18n.numberOfSelects}: </span><span id="numSelected" class="uk-button uk-button-primary uk-button-small"></span><span class="uk-margin-small-left" title="${moduleConfig.i18n.title_numoffiles}">${moduleConfig.i18n.of} ${$maxFiles[fid]}</span>
+            ${renderOrientationSelect(fid)}
+            ${renderColorSelect(fid)}
+            ${renderOrderSelect(fid)}
             <span>${moduleConfig.i18n.totalhitsstring}: ${totalHits}  </span>
             </div>`;
-        $(pager).prependTo($results);
+        $(pager).prependTo($results[fid]);
     }
 
     
@@ -228,7 +255,7 @@ $(document).ready(function () {
     }
 
     
-    function renderImage(item) {
+    function renderImage(item, fid) {
         let firstName = item.user.first_name;
         let lastName = item.user.last_name ? " " + item.user.last_name : "";
         let photographer = firstName + lastName;
@@ -237,10 +264,10 @@ $(document).ready(function () {
         $("<div data-uid='" + item.id + "' class='fImage gridImg " + selected + "' style='background-image: url(" + item.urls.small + ")'>"
             + "<a target='_blank' href='" + userUrl + "'><div class='userData'><img src='" + item.user.profile_image.medium + "'><p>" + photographer + "</p></div></a></div>")
            
-            .appendTo($results)
+            .appendTo($results[fid])
             .on("click", function (e) {
                 $target = $(e.target);
-                if ($(".unsplashChosen .selected").length >= $maxFiles - $numGridImg && !$target.hasClass("selected")){
+                if ($("#unsplashChosen_"+fid+" .selected").length >= $maxFiles[fid] - $numGridImg && !$target.hasClass("selected")){
                     console.log("waz up");
                     shake($(this));
                     return
@@ -251,16 +278,16 @@ $(document).ready(function () {
                 }
 
                 if (!$target.hasClass("selected")) {
-                    renderSelected(item);
+                    renderSelected(item,fid);
                     $(e.currentTarget).addClass("selected");
                     addToLocalstorage(item.id);
-                    $("#numSelected").html($(".unsplashChosen .selected").length);
-                    $(".unsplashChosen").show();
+                    $("#numSelected").html($("#unsplashChosen_"+fid+" .selected").length);
+                    $("#unsplashChosen_"+fid).show();
                 } else {
-                    $(".unsplashChosen .selected[data-uid='" + item.id + "']").remove();
+                    $("#unsplashChosen_"+fid+" .selected[data-uid='" + item.id + "']").remove();
                     $(e.currentTarget).removeClass("selected");
                     removeLocalstorageItem(item.id);
-                    $("#numSelected").html($(".unsplashChosen .selected").length);
+                    $("#numSelected").html($("#unsplashChosen_"+fid+" .selected").length);
                 }
             
             });
@@ -269,7 +296,7 @@ $(document).ready(function () {
 
     //TODO build download link parameters based on image field settings
 
-    function renderSelected(pic) {
+    function renderSelected(pic,fid) {
         let firstName = pic.user.first_name;
         let lastName = pic.user.last_name ? " " + pic.user.last_name : "";
         let photographer = firstName + lastName;
@@ -279,7 +306,7 @@ $(document).ready(function () {
             + "<input multiple id='id-" + page_id + "-" + pic.id + "' type='hidden' name='unsplash_" + field_name + "*" + field_name + "*" + page_id + "*[]' value='" + downloadUrl + "*" + description + ". " + moduleConfig.i18n.photo_by + " " + photographer + ", Unsplash.' />"
             +"<span class='uk-text-primary' uk-icon='icon: check'></span>"
             +"</div>")
-        .appendTo($chosen)
+        .appendTo($chosen[fid])
             .on("click", function (e) {
                 $target = $(e.target);
                 $(".gridImg[data-uid='" + pic.id + "']").first().removeClass("selected");
@@ -288,17 +315,4 @@ $(document).ready(function () {
             });
     }
 
-
-
-    window.addEventListener("beforeunload", function () {
-        $(".unsplashChosen").children().each(function(){
-            $.ajax({
-                type: 'GET',
-                async: true,
-                url: $(this).data("download") + '?client_id=' + apiKey,
-            });
-            
-        })
-        sessionStorage.clear();
-    });
 }); 

--- a/InputfieldSplashAndGrab.module.php
+++ b/InputfieldSplashAndGrab.module.php
@@ -1,5 +1,4 @@
-<?php
-namespace ProcessWire;
+<?php namespace ProcessWire;
 
 class InputfieldSplashAndGrab extends InputfieldImage implements ConfigurableModule {
 
@@ -67,17 +66,17 @@ class InputfieldSplashAndGrab extends InputfieldImage implements ConfigurableMod
 
 		$maximumFiles = $this->maxFiles == 0 ? 'data-maxfiles="999"' : 'data-maxfiles="' . $this->maxFiles . '"'  ;
 			
-		$out .= '<hr /><fieldset id="splashAndGrab" data-uploadedfiles="' . $this->uploadedFiles . '" ' . $maximumFiles . ' class="unsplash" data-id="' . $page->id . '" data-name="'. $field->name .'">';
+		$out .= '<hr /><fieldset id="splashAndGrab_' . $field->id . '" data-uploadedfiles="' . $this->uploadedFiles . '" ' . $maximumFiles . ' class="unsplash" data-id="' . $page->id . '" data-name="'. $field->name .'" data-fieldid="' . $field->id . '">';
 		$out .= '<div uk-grid class="uk-flex-bottom">';
 		$out .= '<div>';
-		$out .= '<label for="unsplashMagic" class="uk-form-label">' . __("Search Unsplash") . '';
-		$out .= '<input type="text" id="unsplashMagic" class="unsplashSearch"/></label>';
+		$out .= '<label for="unsplashMagic_' . $field->id . '" class="uk-form-label">' . __("Search Unsplash") . '';
+		$out .= '<input type="text" id="unsplashMagic_' . $field->id . '" class="unsplashSearch"/></label>';
 		$out .= '</div>';
 		$out .= '<div>';
 		$out .= '<button class="unsplashButton ui-button ui-widget ui-corner-all ui-state-default"><span class="ui-button-text">' . __("Search") . '</span></button>';
 		$out .= '</div>';
 		$out .= '</div>';
-		$out .= '<div class="unsplashChosen"></div><div class="unsplashResults"><div class="resultsItems"></div></div></fieldset>';
+		$out .= '<div id="unsplashChosen_' . $field->id . '" class="unsplashChosen"></div><div id="unsplashResults_' . $field->id . '" class="unsplashResults"><div class="resultsItems"></div></div></fieldset>';
 		$event->return = $out;
 
 	}
@@ -171,7 +170,7 @@ class InputfieldSplashAndGrab extends InputfieldImage implements ConfigurableMod
 				}
 
 				$pagefile = new Pageimage($field_value, $img[0]);
-				$pagefile->rename($pagefile . ".jpg");
+				$pagefile->rename(str_replace('.', '-', $pagefile) . ".jpg");
 				$field_value->add($pagefile);
 				$image = $field_value->last();
 				$image->description = $img[1];
@@ -192,7 +191,7 @@ class InputfieldSplashAndGrab extends InputfieldImage implements ConfigurableMod
 		$inputfields = new InputfieldWrapper();
 
         $fieldImage = $modules->get("InputfieldAsmSelect");
-        $fieldImage->name = "useField";
+        $fieldImage->name = 'useField';
         $fieldImage->label = __("Image fields that should use the module.");
         $fieldImage->description = __("Choose the fields which should use the module.");
         foreach ($this->getImagefields() as $img) {


### PR DESCRIPTION
This updated code modifies original to allow for separate multiple instances of splash and grab image inputfields on a single template form. Originally if you had several image fields that implemented splash and grab query on a single form template, they would all mirror the same behavior and would save the same data.

With this code modification each inputfield instance operated and saves independently as it should.

## InputfieldSplashAndGrab.module.php

Markup is modified to include _fieldid as a suffix. e.g. id="splashAndGrab_150" instead of id="splashAndGrab".

## InputfieldSplashAndGrab.js

JS is modified to expand variables from the original instance setup to allow for any number of splash and grab fields on the page, each one working and saving independently.

Functions without arguments now have a field argument (fid). This was also added to the end of getImages(), meaning getImages(query) no longer works as intended.